### PR TITLE
fix partialProtoBytes[4] for 352-char token

### DIFF
--- a/src/com/jackpf/apkdownloader/Service/PlayApi.java
+++ b/src/com/jackpf/apkdownloader/Service/PlayApi.java
@@ -157,7 +157,7 @@ public class PlayApi
         ).build();
         
         byte partialProtoBytes[] = proto.toByteArray();
-        partialProtoBytes[4] = -53; // Ahem...
+        partialProtoBytes[4] -= 2;
         
         ArrayList<Byte> packageNameByteList = new ArrayList<Byte>();
         packageNameByteList.add((byte) 19);


### PR DESCRIPTION
I didn't check either whether/how this can be done properly via protobuf, but the auth token size has changed...
